### PR TITLE
Enable Withdrawals for more Dawn Breaker Seasonal Items

### DIFF
--- a/src/features/game/types/withdrawables.ts
+++ b/src/features/game/types/withdrawables.ts
@@ -392,12 +392,13 @@ const decorations: Record<ShopDecorationName, boolean> = {
   "Golden Maple": false,
 };
 const seasonalDecorations: Record<SeasonalDecorationName, boolean> = {
-  Clementine: false,
-  Cobalt: false,
-  "Dawn Umbrella Seat": false,
-  "Eggplant Grill": false,
-  "Giant Dawn Mushroom": false,
-  "Shroom Glow": false,
+  Clementine: true,
+  Cobalt: true,
+  "Dawn Umbrella Seat": true,
+  "Eggplant Grill": true,
+  "Giant Dawn Mushroom": true,
+  "Shroom Glow": true,
+  
   Candles: false,
   "Haunted Stump": false,
   "Spooky Tree": false,
@@ -425,7 +426,7 @@ const points: Record<Points, boolean> = {
 const goblinBlacksmith: Record<GoblinBlacksmithItemName, boolean> = {
   "Mushroom House": true,
   Obie: true,
-  "Purple Trail": false,
+  "Purple Trail": true,
   Maximus: true,
 };
 
@@ -552,17 +553,17 @@ const treasureDecoration: Record<DecorationTreasure, boolean> = {
   "Sunflower Coin": true,
   "Pirate Bear": true,
   "Whale Bear": true,
-
+  "Lifeguard Bear": true,
+  "Snorkel Bear": true,
+  "Turtle Bear": true,
+  
   "Abandoned Bear": false,
   "Dinosaur Bone": false,
   Galleon: false,
   "Golden Bear Head": false,
   "Human Bear": false,
-  "Lifeguard Bear": false,
   "Parasaur Skull": false,
   "Skeleton King Staff": false,
-  "Snorkel Bear": false,
-  "Turtle Bear": false,
   "Goblin Bear": false,
 };
 
@@ -586,20 +587,20 @@ const eventDecoration: Record<EventDecorationName, boolean> = {
   "Easter Bear": true,
   "Easter Bush": true,
   "Giant Carrot": true,
-  "Genie Bear": false,
+  "Genie Bear": true,
   "Eggplant Bear": true,
-  "Dawn Flower": false,
+  "Dawn Flower": true,
 };
 
 const lanterns: Record<LanternName, boolean> = {
-  "Luminous Lantern": false,
-  "Radiance Lantern": false,
-  "Aurora Lantern": false,
-  "Ocean Lantern": false,
-  "Solar Lantern": false,
-  "Betty Lantern": false,
-  "Bumpkin Lantern": false,
-  "Goblin Lantern": false,
+  "Luminous Lantern": true,
+  "Radiance Lantern": true,
+  "Aurora Lantern": true,
+  "Ocean Lantern": true,
+  "Solar Lantern": true,
+  "Betty Lantern": true,
+  "Bumpkin Lantern": true,
+  "Goblin Lantern": true,
 };
 
 const purchasables: Record<PurchasableItems, boolean> = {


### PR DESCRIPTION
# Description

Now that Dawn Breaker Season has ended, I think it's time to allow these collectibles to be withdrawn:
Clementine
Cobalt
Dawn Umbrella Seat
Eggplant Grill
Giant Dawn Mushroom
Shroom Glow

Purple Trail

Lifeguard Bear
Snorkel Bear
Turtle Bear
Genie Bear
Dawn Flower

Luminous Lantern
Radiance Lantern
Aurora Lantern
Ocean Lantern
Solar Lantern
Betty Lantern
Bumpkin Lantern
Goblin Lantern

Fixes #issue

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [ ] Screenshot if it includes any UI changes
- [ ] I have read the contributing guidelines and agree to the T&Cs
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
